### PR TITLE
feat(auth): agrega soporte de roles de usuario y navegación según rol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 dist
 node_modules
 .env
-src/app/enviroments/enviroment/enviroment.ts
+enviroment.ts

--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -1,8 +1,7 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { AuthService } from '../../services/auth.service';
-import { Router } from '@angular/router';
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+import {AuthService} from '../../services/auth.service';
 
 @Component({
   selector: 'app-login',
@@ -20,24 +19,24 @@ import { Router } from '@angular/router';
           <div class="form-group">
             <label for="email">Email</label>
             <input
-              type="email"
-              id="email"
-              [(ngModel)]="email"
-              name="email"
-              placeholder="tu@email.com"
-              required
+                type="email"
+                id="email"
+                [(ngModel)]="email"
+                name="email"
+                placeholder="tu@email.com"
+                required
             />
           </div>
 
           <div class="form-group">
             <label for="password">Contraseña</label>
             <input
-              type="password"
-              id="password"
-              [(ngModel)]="password"
-              name="password"
-              placeholder="••••••••"
-              required
+                type="password"
+                id="password"
+                [(ngModel)]="password"
+                name="password"
+                placeholder="••••••••"
+                required
             />
           </div>
 
@@ -59,8 +58,8 @@ import { Router } from '@angular/router';
           </div>
           <div class="demo-account">
             <strong>Usuario:</strong><br>
-            Email: walacapps&#64;gmail.com<br>
-            Contraseña: WalacMasoki13.
+            Email: alejandrofmayor98&#64;gmail.com<br>
+            Contraseña: Geoymunicipal123
           </div>
         </div>
       </div>
@@ -185,25 +184,21 @@ export class LoginComponent {
   password = '';
   errorMessage = '';
 
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(private readonly authService: AuthService) {
+  }
 
   async login(): Promise<void> {
-    this.errorMessage = '';
-    try {
-      const success = await this.authService.login(this.email, this.password);
-      if (!success) {
-        this.errorMessage = 'Email o contraseña incorrectos';
-      } else {
-        // Redirige según el rol (por ahora role viene de metadata como 'user' por defecto)
-        if (this.authService.isAdmin()) {
-          this.router.navigate(['/admin']);
-        } else {
-          this.router.navigate(['/user']);
-        }
-      }
-    } catch (error) {
-      this.errorMessage = 'Error inesperado, intenta nuevamente';
-      console.error(error);
+  this.errorMessage = '';
+  try {
+    const user = await this.authService.loginWithRole(this.email, this.password);
+    if (!user) {
+      this.errorMessage = 'Email o contraseña incorrectos';
     }
+  } catch (error) {
+    this.errorMessage = 'Error inesperado, intenta nuevamente';
+    console.error(error);
   }
+}
+
+
 }

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -2,19 +2,23 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
-export const adminGuard: CanActivateFn = (_route, _state) => {
+export const adminGuard: CanActivateFn = async (_route, _state) => { // 👈 async
   const auth = inject(AuthService);
   const router = inject(Router);
 
-  if (auth.isAuthenticated() && auth.isAdmin()) {
+  const loggedIn = auth.isAuthenticated();
+  const admin = await auth.isAdmin();
+
+  if (loggedIn && admin) {
     return true;
   }
 
-  // Si está autenticado pero no es admin, lo mandamos a su panel de usuario
-  if (auth.isAuthenticated()) {
-    router.navigate(['/user']);
+  // Si está autenticado pero no es admin
+  if (loggedIn) {
+    await router.navigate(['/user']);
   } else {
-    router.navigate(['/login']);
+    await router.navigate(['/login']);
   }
+
   return false;
 };

--- a/src/app/models/user-roles.enum.ts
+++ b/src/app/models/user-roles.enum.ts
@@ -1,0 +1,6 @@
+// src/app/models/user-roles.enum.ts
+export enum UserRole {
+  ADMIN = 'ADMIN',
+  OWNER = 'OWNER',
+  CLIENT = 'CLIENT',
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,18 +1,21 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
-import { createClient, SupabaseClient, User as SupabaseUser } from '@supabase/supabase-js';
-import { User } from '../models/interfaces';
-import { environment } from '../enviroments/enviroment/enviroment';
+import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+import {createClient, SupabaseClient, User as SupabaseUser} from '@supabase/supabase-js';
+import {User} from '../models/interfaces';
+import {environment} from '../enviroments/enviroment/enviroment';
+import {UserRole} from "../models/user-roles.enum";
+import {Router} from "@angular/router";
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuthService {
-  private supabase: SupabaseClient;
-  private currentUserSubject = new BehaviorSubject<User | null>(null);
+  private readonly supabase: SupabaseClient;
+  private readonly currentUserSubject = new BehaviorSubject<User | null>(null);
   public currentUser$ = this.currentUserSubject.asObservable();
 
-  constructor() {
+
+  constructor(private readonly router: Router) {
     this.supabase = createClient(environment.supabaseUrl, environment.supabaseKey);
     this.loadUserFromSession();
 
@@ -44,33 +47,77 @@ export class AuthService {
     }
   }
 
-  async login(email: string, password: string): Promise<boolean> {
-    const { data, error } = await this.supabase.auth.signInWithPassword({ email, password });
-    if (error) {
-      console.error('Error en login:', error.message);
-      return false;
-    }
-    if (data.user) {
-      this.setCurrentUser(data.user);
-      return true;
-    }
-    return false;
-  }
+
 
   async logout(): Promise<void> {
     await this.supabase.auth.signOut();
     this.currentUserSubject.next(null);
     localStorage.removeItem('currentUser');
+    await this.router.navigate(['/']);
   }
 
   getCurrentUser(): User | null {
     return this.currentUserSubject.value;
   }
 
-  isAdmin(): boolean {
-    const user = this.getCurrentUser();
-    return user?.role === 'admin';
+private async fetchUserProfile(userId: string) {
+  const { data: perfil, error } = await this.supabase
+    .from('perfiles')
+    .select('rol')
+    .eq('id', userId)
+    .single();
+  if (error) {
+    console.error('Error fetching perfil:', error);
+    return null;
   }
+  return perfil;
+}
+
+async loginWithRole(email: string, password: string): Promise<User | null> {
+  const { data, error } = await this.supabase.auth.signInWithPassword({ email, password });
+  if (error || !data.user) {
+    console.error('Error en login:', error?.message);
+    return null;
+  }
+
+  this.setCurrentUser(data.user);
+
+  const perfil = await this.fetchUserProfile(data.user.id);
+  const role = perfil?.rol ?? 'user';
+
+  const userWithRole: User = {
+    id: data.user.id,
+    email: data.user.email ?? '',
+    name: data.user.user_metadata?.['full_name'] ?? '',
+    role,
+  };
+
+  this.currentUserSubject.next(userWithRole);
+  localStorage.setItem('currentUser', JSON.stringify(userWithRole));
+
+  if (userWithRole.role.toUpperCase() === UserRole.ADMIN) {
+    await this.router.navigate(['/admin']);
+  } else {
+    await this.router.navigate(['/user']);
+  }
+
+  return userWithRole;
+}
+
+async isAdmin(): Promise<boolean> {
+  const user = this.getCurrentUser();
+  if (!user) return false;
+
+  // Si ya tienes el rol en el usuario, lo puedes usar directamente sin hacer consulta
+  if (user.role.toUpperCase() === UserRole.ADMIN) {
+    return true;
+  }
+
+  // Si quieres asegurarte que el rol está actualizado, haz consulta:
+  const perfil = await this.fetchUserProfile(user.id);
+  return perfil?.rol.toUpperCase() === UserRole.ADMIN;
+}
+
 
   isAuthenticated(): boolean {
     return this.getCurrentUser() !== null;


### PR DESCRIPTION
Se implementa enum de roles, consulta de perfil en Supabase y login con asignación de rol. Se adaptan los guards, el servicio de auth y el login para navegación automática. Permite distinguir entre ADMIN, OWNER y CLIENT.
Refactoriza la comprobación de admin a función asíncrona y ajusta el guard.